### PR TITLE
Fix dataset download issue for large files from Google Drive

### DIFF
--- a/download_how2sign.sh
+++ b/download_how2sign.sh
@@ -12,10 +12,9 @@
 ################################################################################
 
 # Provide at least one argument to script
-if (( $# < 1 ))
-then
-	echo "USAGE: $0 <argument1> <argument2> ..."
-	exit
+if [ $# -lt 1 ]; then
+    echo "USAGE: $0 <argument1> <argument2> ..."
+    exit
 fi
 
 echo "Downloading the How2Sign dataset"
@@ -24,61 +23,115 @@ echo "Downloading the How2Sign dataset"
 # Create folder structure and download data #
 #############################################
 
+DOWNLOAD_SCRIPT="./download_script.sh"
+
+
+check_quota_exceeded() {
+    # Use a timeout to prevent long grep operations on large files
+    if timeout 10 grep -q "Google Drive - Quota exceeded" "$1"; then
+        echo "Quota exceeded error detected in $1."
+        return 1 # Indicates error
+    elif [ $? -eq 124 ]; then
+        return 0 # Assume no error if timeout occurs
+    fi
+    return 0 # No error
+}
+
+# Download file if not exists or if error detected
+download_file() {
+    local url=$1
+    local path=$2
+
+    # Loop until the file is downloaded without errors
+    while true; do
+        # Check if the file exists
+        if [ -f "$path" ]; then
+            echo "File $path already exists, checking content..."
+            # Check for Google Drive quota exceeded error
+            check_quota_exceeded "$path"
+            quota_exceeded=$?
+            if [ $quota_exceeded -eq 0 ]; then
+                echo "File $path is free of errors."
+                break # Exit loop if no error
+            else
+                echo "Redownloading $path due to error detection."
+            fi
+        else
+            echo "File $path does not exist, initiating download..."
+        fi
+
+        # If file doesn't exist or error detected, download
+        echo "Downloading $path..."
+        sh $DOWNLOAD_SCRIPT "$url" "$path"
+
+        # Check again if newly downloaded file has error
+        check_quota_exceeded "$path"
+        quota_exceeded=$?
+        if [ $quota_exceeded -eq 0 ]; then
+            echo "File $path downloaded successfully and verified."
+            break # Exit loop if file is correctly downloaded
+        else
+            echo "Error detected post-download, retrying..."
+            sleep 1800 # Optional: Sleep to prevent hammering the server too quickly
+        fi
+    done
+}
+
+
 #------------------------- Green Screen RGB videos - Frontal View -------------------------#
-rgb_front_videos()
-{
-	mkdir -p "./How2Sign/video_level/train/rgb_front"
-	mkdir -p "./How2Sign/video_level/val/rgb_front"
-	mkdir -p "./How2Sign/video_level/test/rgb_front"
+rgb_front_videos() {
+    mkdir -p "./How2Sign/video_level/train/rgb_front"
+    mkdir -p "./How2Sign/video_level/val/rgb_front"
+    mkdir -p "./How2Sign/video_level/test/rgb_front"
 
-	echo "***** Downloading Green Screen RGB videos (Frontal View)... You can go get a coffee, this might take a while!*****"
+    echo "***** Downloading Green Screen RGB videos (Frontal View)... You can go get a coffee, this might take a while!*****"
 
-	## Train
-	### train_raw_videos.z01
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1xWlMM2O3Gbp_8LK5FefoH0TVEmae6jIf' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1xWlMM2O3Gbp_8LK5FefoH0TVEmae6jIf" -O train_raw_videos.z01 && rm -rf /tmp/cookies.txt
+    ## Train
+    ### train_raw_videos.z01
+    download_file 'https://docs.google.com/uc?export=download&id=1xWlMM2O3Gbp_8LK5FefoH0TVEmae6jIf' 'train_raw_videos.z01'
 
 	### train_raw_videos.z02
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1krtYdpK_LQFgEUCnHxoYAW7EyhLMLWq0' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1krtYdpK_LQFgEUCnHxoYAW7EyhLMLWq0" -O train_raw_videos.z02 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1krtYdpK_LQFgEUCnHxoYAW7EyhLMLWq0' 'train_raw_videos.z02'
 
 	### train_raw_videos.z03
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1fXpWRNFhpuVm3ym7lT9vF_bnDjHkvP_K' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1fXpWRNFhpuVm3ym7lT9vF_bnDjHkvP_K" -O train_raw_videos.z03 && rm -rf /tmp/cookies.txt
-
+    download_file 'https://docs.google.com/uc?export=download&id=1fXpWRNFhpuVm3ym7lT9vF_bnDjHkvP_K' 'train_raw_videos.z03'
+	
 	### train_raw_videos.z04
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1IFetFt4AzsxNCMZ0VVpX7YRgFAm58X48' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1IFetFt4AzsxNCMZ0VVpX7YRgFAm58X48" -O train_raw_videos.z04 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1IFetFt4AzsxNCMZ0VVpX7YRgFAm58X48' 'train_raw_videos.z04'
 
 	### train_raw_videos.z05
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1ZHuuun6Ae-AOLBns3LmuH7w8C9YCB4gH' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1ZHuuun6Ae-AOLBns3LmuH7w8C9YCB4gH" -O train_raw_videos.z05 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1ZHuuun6Ae-AOLBns3LmuH7w8C9YCB4gH' 'train_raw_videos.z05'
 
 	### train_raw_videos.z06
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1FQQIPblk-oLH_vu7h2tDO0oJaZ3xkp5N' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1FQQIPblk-oLH_vu7h2tDO0oJaZ3xkp5N" -O train_raw_videos.z06 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1FQQIPblk-oLH_vu7h2tDO0oJaZ3xkp5N' 'train_raw_videos.z06'
 
 	### train_raw_videos.z07
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=19XNgERcolGAMPPgX-Gx_GebSTx3W4o0r' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=19XNgERcolGAMPPgX-Gx_GebSTx3W4o0r" -O train_raw_videos.z07 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=19XNgERcolGAMPPgX-Gx_GebSTx3W4o0r' 'train_raw_videos.z07'
 
 	### train_raw_videos.z08
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1YN-SA9uzrogEdKeT6UdQUIcuGEyYJILg' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1YN-SA9uzrogEdKeT6UdQUIcuGEyYJILg" -O train_raw_videos.z08 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1YN-SA9uzrogEdKeT6UdQUIcuGEyYJILg' 'train_raw_videos.z08'
 
 	### train_raw_videos.z09
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1SZQ2GzPLCkRqvsImAjULAPBiuAKi9DE9' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1SZQ2GzPLCkRqvsImAjULAPBiuAKi9DE9" -O train_raw_videos.z09 && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1SZQ2GzPLCkRqvsImAjULAPBiuAKi9DE9' 'train_raw_videos.z09'
 
 	### train_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1Xe1T5okJiopMXUiH3sc0mdCWNDYSBopd' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1Xe1T5okJiopMXUiH3sc0mdCWNDYSBopd" -O train_raw_videos.zip && rm -rf /tmp/cookies.txt
+    download_file 'https://docs.google.com/uc?export=download&id=1Xe1T5okJiopMXUiH3sc0mdCWNDYSBopd' 'train_raw_videos.zip'
+    
+    ## Val
+    ### val_raw_videos.zip
+    download_file 'https://docs.google.com/uc?export=download&id=1fCkyuKSsc7gauljuL9sx_jBomf3N6i0g' 'val_raw_videos.zip'
 
-	## Val
-	### val_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1fCkyuKSsc7gauljuL9sx_jBomf3N6i0g' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1fCkyuKSsc7gauljuL9sx_jBomf3N6i0g" -O val_raw_videos.zip && rm -rf /tmp/cookies.txt
+    ## Test
+    ### test_raw_videos.zip
+    download_file 'https://docs.google.com/uc?export=download&id=1z0i6BBGHQ12ChY63hZH56QnczvQ0JfTb' 'test_raw_videos.zip'
 
-	## Test
-	### test_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1z0i6BBGHQ12ChY63hZH56QnczvQ0JfTb' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1z0i6BBGHQ12ChY63hZH56QnczvQ0JfTb" -O test_raw_videos.zip && rm -rf /tmp/cookies.txt
+    # Merge all train zip files
+    echo "***** Preparing the downloaded files... this might take some time! *****"
+    cat train_raw_videos.z* > train_raw_videos_all.zip
 
-	# Merge all train zip files
-	echo "***** Preparing the downloaded files... this might take some time! *****"
-	cat train_raw_videos.z* > train_raw_videos_all.zip
-
-	unzip train_raw_videos_all.zip -d ./How2Sign/video_level/train/rgb_front && rm -rf train_raw_videos_all.zip
-	unzip val_raw_videos.zip   -d ./How2Sign/video_level/val/rgb_front && rm -rf val_raw_videos.zip
-	unzip test_raw_videos.zip  -d ./How2Sign/video_level/test/rgb_front && rm -rf test_raw_videos.zip
+    unzip train_raw_videos_all.zip -d ./How2Sign/video_level/train/rgb_front && rm -rf train_raw_videos_all.zip
+    unzip val_raw_videos.zip   -d ./How2Sign/video_level/val/rgb_front && rm -rf val_raw_videos.zip
+    unzip test_raw_videos.zip  -d ./How2Sign/video_level/test/rgb_front && rm -rf test_raw_videos.zip
 }
 
 #------------------------- Green Screen RGB videos - Side View -------------------------#
@@ -92,42 +145,42 @@ rgb_side_videos()
 
 	## Train
 	### train_side_raw_videos.z01
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1Rmf6LfNWn6lWkAz6Iuj5pMOI2I5p4j1U' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1Rmf6LfNWn6lWkAz6Iuj5pMOI2I5p4j1U" -O train_side_raw_videos.z01 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1Rmf6LfNWn6lWkAz6Iuj5pMOI2I5p4j1U' 'train_side_raw_videos.z01'
 
 	### train_side_raw_videos.z02
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1FytIYIRYrBgAeNWIAhO5vnI2mYOvYC9i' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1FytIYIRYrBgAeNWIAhO5vnI2mYOvYC9i" -O train_side_raw_videos.z02 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1FytIYIRYrBgAeNWIAhO5vnI2mYOvYC9i' 'train_side_raw_videos.z02'
 
 	### train_side_raw_videos.z03
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1kC24jgNgjYYiIYhCRE-gGR28H_2xBBbP' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1kC24jgNgjYYiIYhCRE-gGR28H_2xBBbP" -O train_side_raw_videos.z03 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1kC24jgNgjYYiIYhCRE-gGR28H_2xBBbP' 'train_side_raw_videos.z03'
 
 	### train_side_raw_videos.z04
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1JunkM-ImFYao_MwDW9zeqe-6Th6rOLhR' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1JunkM-ImFYao_MwDW9zeqe-6Th6rOLhR" -O train_side_raw_videos.z04 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1JunkM-ImFYao_MwDW9zeqe-6Th6rOLhR' 'train_side_raw_videos.z04'
 
 	### train_side_raw_videos.z05
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1-vMckelz9fy4GVNYXRCcy7cJ12X4P3KZ' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1-vMckelz9fy4GVNYXRCcy7cJ12X4P3KZ" -O train_side_raw_videos.z05 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1-vMckelz9fy4GVNYXRCcy7cJ12X4P3KZ' 'train_side_raw_videos.z05'
 
 	### train_side_raw_videos.z06
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1uV413eKsihkNzquN2bwtIQG-OZZMz6sh' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1uV413eKsihkNzquN2bwtIQG-OZZMz6sh" -O train_side_raw_videos.z06 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1uV413eKsihkNzquN2bwtIQG-OZZMz6sh' 'train_side_raw_videos.z06'
 
 	### train_side_raw_videos.z07
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1sU8xrneFJHBzT_PFz4iRPqI8A7HGilhW' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1sU8xrneFJHBzT_PFz4iRPqI8A7HGilhW" -O train_side_raw_videos.z07 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1sU8xrneFJHBzT_PFz4iRPqI8A7HGilhW' 'train_side_raw_videos.z07'
 
 	### train_side_raw_videos.z08
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1RPLxeZ54uSZUJSXdPFhXOgeIXziOwTW9' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1RPLxeZ54uSZUJSXdPFhXOgeIXziOwTW9" -O train_side_raw_videos.z08 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1RPLxeZ54uSZUJSXdPFhXOgeIXziOwTW9' 'train_side_raw_videos.z08'
 
 	### train_side_raw_videos.z09
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1tClhr98PszBvFpo9ELKuhbTZZgTGGQqh' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1tClhr98PszBvFpo9ELKuhbTZZgTGGQqh" -O train_side_raw_videos.z09 && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1tClhr98PszBvFpo9ELKuhbTZZgTGGQqh' 'train_side_raw_videos.z09'
 
 	### train_side_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=10xrXWgH7iW3E6sgJZDPRwlIhIaDLfHQm' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=10xrXWgH7iW3E6sgJZDPRwlIhIaDLfHQm" -O train_side_raw_videos.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=10xrXWgH7iW3E6sgJZDPRwlIhIaDLfHQm' 'train_side_raw_videos.zip'
 	
 	## Val
 	### val_rgb_side_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1Z2H96JT68o7eTChEXPI9z3xyx7zUJPl5' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1Z2H96JT68o7eTChEXPI9z3xyx7zUJPl5" -O val_rgb_side_raw_videos.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1Z2H96JT68o7eTChEXPI9z3xyx7zUJPl5' 'val_rgb_side_raw_videos.zip'
 
 	## Test
 	### test_rgb_side_raw_videos.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1tCQ8KIuuiirXHsh29w0XAMNB3HLIGqgA' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1tCQ8KIuuiirXHsh29w0XAMNB3HLIGqgA" -O test_rgb_side_raw_videos.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1tCQ8KIuuiirXHsh29w0XAMNB3HLIGqgA' 'test_rgb_side_raw_videos.zip'
 
 	# Merge all train zip files
 	echo "***** Preparing the downloaded files... this might take some time! *****"
@@ -149,16 +202,16 @@ rgb_front_clips()
 
 	## Train
 	### train_rgb_front_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1VX7n0jjW0pW3GEdgOks3z8nqE6iI6EnW' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1VX7n0jjW0pW3GEdgOks3z8nqE6iI6EnW" -O train_rgb_front_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1VX7n0jjW0pW3GEdgOks3z8nqE6iI6EnW' 'train_rgb_front_clips.zip'
 
 	## Val
 	### val_rgb_front_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1DhLH8tIBn9HsTzUJUfsEOGcP4l9EvOiO' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1DhLH8tIBn9HsTzUJUfsEOGcP4l9EvOiO" -O val_rgb_front_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1DhLH8tIBn9HsTzUJUfsEOGcP4l9EvOiO' 'val_rgb_front_clips.zip'
 
 
 	## Test
 	### test_rgb_front_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1qTIXFsu8M55HrCiaGv7vZ7GkdB3ubjaG' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1qTIXFsu8M55HrCiaGv7vZ7GkdB3ubjaG" -O test_rgb_front_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1qTIXFsu8M55HrCiaGv7vZ7GkdB3ubjaG' 'test_rgb_front_clips.zip'
 
 	unzip train_rgb_front_clips.zip -d ./How2Sign/sentence_level/train/rgb_front && rm -rf train_rgb_front_clips.zip
 	unzip val_rgb_front_clips.zip   -d ./How2Sign/sentence_level/val/rgb_front && rm -rf val_rgb_front_clips.zip
@@ -176,15 +229,15 @@ rgb_side_clips()
 
 	## Train
 	### train_rgb_side_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1oiw861NGp4CKKFO3iuHGSCgTyQ-DXHW7' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1oiw861NGp4CKKFO3iuHGSCgTyQ-DXHW7" -O train_rgb_side_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1oiw861NGp4CKKFO3iuHGSCgTyQ-DXHW7' 'train_rgb_side_clips.zip'
 
 	## Val
 	### val_rgb_side_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1mxL7kJPNUzJ6zoaqJyxF1Krnjo4F-eQG' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1mxL7kJPNUzJ6zoaqJyxF1Krnjo4F-eQG" -O val_rgb_side_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1mxL7kJPNUzJ6zoaqJyxF1Krnjo4F-eQG' 'val_rgb_side_clips.zip'
 
 	## Test
 	### test_rgb_side_clips.zip
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1j9v9P7UdMJ0_FVWg8H95cqx4DMSsrdbH' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1j9v9P7UdMJ0_FVWg8H95cqx4DMSsrdbH" -O test_rgb_side_clips.zip && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1j9v9P7UdMJ0_FVWg8H95cqx4DMSsrdbH' 'test_rgb_side_clips.zip'
 
 
 	unzip train_rgb_side_clips.zip -d ./How2Sign/sentence_level/train/rgb_side && rm -rf train_rgb_side_clips.zip
@@ -202,15 +255,15 @@ rgb_front_2D_keypoints()
 	echo "***** Downloading B-F-H 2D Keypoints clips (Frontal view) files... This might take a while! *****"
 	## Train
 	### train_2D_keypoints.tar.gz
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1TBX7hLraMiiLucknM1mhblNVomO9-Y0r' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1TBX7hLraMiiLucknM1mhblNVomO9-Y0r" -O train_2D_keypoints.tar.gz && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1TBX7hLraMiiLucknM1mhblNVomO9-Y0r' 'train_2D_keypoints.tar.gz'
 
 	## Val
 	### val_2D_keypoints.tar.gz
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1JmEsU0GYUD5iVdefMOZpeWa_iYnmK_7w' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1JmEsU0GYUD5iVdefMOZpeWa_iYnmK_7w" -O val_2D_keypoints.tar.gz && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1JmEsU0GYUD5iVdefMOZpeWa_iYnmK_7w' 'val_2D_keypoints.tar.gz'
 
 	## Test
 	### test_2D_keypoints.tar.gz
-	wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1g8tzzW5BNPzHXlamuMQOvdwlHRa-29Vp' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=1g8tzzW5BNPzHXlamuMQOvdwlHRa-29Vp" -O test_2D_keypoints.tar.gz && rm -rf /tmp/cookies.txt
+	download_file 'https://docs.google.com/uc?export=download&id=1g8tzzW5BNPzHXlamuMQOvdwlHRa-29Vp' 'test_2D_keypoints.tar.gz'
 
 	echo "***** Preparing the downloaded files... this might take some time! *****"
 	tar -xf train_2D_keypoints.tar.gz -C ./How2Sign/sentence_level/train/rgb_front/features && rm -rf train_2D_keypoints.tar.gz

--- a/download_script.sh
+++ b/download_script.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <file_url> <destination_path>"
+    exit 1
+fi
+
+file_url=$1
+destination_path=$2
+
+confirmation_page=$(curl -s -L "$file_url")
+
+file_id=$(echo "$confirmation_page" | grep -oE "name=\"id\" value=\"[^\"]+" | sed 's/name="id" value="//')
+file_confirm=$(echo "$confirmation_page" | grep -oE "name=\"confirm\" value=\"[^\"]+" | sed 's/name="confirm" value="//')
+file_uuid=$(echo "$confirmation_page" | grep -oE "name=\"uuid\" value=\"[^\"]+" | sed 's/name="uuid" value="//')
+
+download_url="https://drive.usercontent.google.com/download?id=$file_id&export=download&confirm=$file_confirm&uuid=$file_uuid"
+
+curl -L -o "$destination_path" "$download_url"


### PR DESCRIPTION
This commit resolves the problem where large dataset files could not be directly downloaded due to Google Drive's virus scan warning. The updated download script now handles the confirmation step automatically, bypassing the virus scan verification and allowing seamless dataset acquisition.

In addition, Google Drive implements a traffic quota for the user IP, which limits the amount of user traffic to its servers. This causes the download of an error HTML page 'Google Drive - Quota exceeded' instead of the desired file. The new version detects if this error occurs and retries the download after half an hour until the file can be successfully downloaded.